### PR TITLE
inverted assertion

### DIFF
--- a/IBM Proactive Technology Online/ProtonJ2SE/src/com/ibm/hrl/proton/metadata/type/TypeAttributeSet.java
+++ b/IBM Proactive Technology Online/ProtonJ2SE/src/com/ibm/hrl/proton/metadata/type/TypeAttributeSet.java
@@ -60,7 +60,7 @@ public class TypeAttributeSet implements Serializable{
 	
 	public TypeAttribute getAttribute(String attName)
 	{
-		assert (!typeAttributes.containsKey(attName));
+		assert (typeAttributes.containsKey(attName));
 		
 		return typeAttributes.get(attName);
 	}


### PR DESCRIPTION
Before the proposed change the getAttribute method will return null or fail, when assertions are enabled.
Therefore the assertion has been inverted.